### PR TITLE
Add linenumber colors to config-highlight.cfg

### DIFF
--- a/config-highlight.cfg
+++ b/config-highlight.cfg
@@ -40,3 +40,6 @@ hit-foreground        = #ffffff
 
 break-background      = #000000
 break-foreground      = #ffffff
+
+linenumber-background = #272822
+linenumber-foreground = #f8f8f2


### PR DESCRIPTION
IDLE got updated with Python 3.10 and now it can show line numbers. Added support for it.